### PR TITLE
Change GitHub from SSH authentication to using a Personal Access Token

### DIFF
--- a/src/main/resources/ascent-config.yml
+++ b/src/main/resources/ascent-config.yml
@@ -12,7 +12,13 @@ spring:
       enabled: false
     config:
       server:
+        vault:
+          order: 0
+          host: ${VAULT_HOST:vault}
+          port: ${VAULT_PORT:8200}
+          scheme: ${VAULT_SCHEME:http}          
         git:
+          order: 1
           uri: https://github.com/department-of-veterans-affairs/ascent-ext-configs.git
           username: ${git.access_token}
           password: 
@@ -25,14 +31,6 @@ security:
   user:
     name: ${config.username:config}
     password: ${config.password:default}
-encrypt:
-  #ConfigurationProperties-KeyProperties
-  keyStore:
-    location: classpath:/configServer.jks
-    #password and secret can be provided as startup or env variables
-    password: configmein
-    alias: configkey
-    secret: configme
 management:
   security:
     enabled: false

--- a/src/main/resources/ascent-config.yml
+++ b/src/main/resources/ascent-config.yml
@@ -13,9 +13,9 @@ spring:
     config:
       server:
         git:
-          uri: git@github.com:department-of-veterans-affairs/ascent-ext-configs.git
-          passphrase: ${git.passphrase}
-          strictHostKeyChecking: false
+          uri: https://github.com/department-of-veterans-affairs/ascent-ext-configs.git
+          username: ${git.access_token}
+          password: 
           cloneOnStart: true
           timeout: 10
           searchPaths: ascent*

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -29,6 +29,7 @@ eureka:
 
 spring:
   profiles: docker-demo
+spring.profiles.include: vault, git
 eureka:
   client:
     enabled: true
@@ -40,7 +41,8 @@ eureka:
 ---
 
 spring:
-    profiles: aws-ci, aws-dev, aws-stage, aws-prod
+  profiles: aws-ci, aws-dev, aws-stage, aws-prod
+spring.profiles.include: vault,git
 eureka:
   client:
     enabled: true


### PR DESCRIPTION
Changing from SSH authentication for GitHub to using a Personal Access Token. This would require a change to how your developer authenticate locally, replacing the git ssh key password in your .env file with a Personal Access Token they generated on GitHub. 